### PR TITLE
Always write the `network` field if no field in input.

### DIFF
--- a/cmd_import.go
+++ b/cmd_import.go
@@ -110,6 +110,7 @@ Options:
       default: false.
     --no-fields
       specify that no fields exist except the implicit network field.
+      when enabled, --no-network has no effect; the network field is written.
       default: false.
     --no-network
       if --fields-from-header is set, then don't write the network field, which
@@ -257,6 +258,7 @@ func cmdImport() error {
 	}
 	if fNoFields {
 		fFields = []string{}
+		fNoNetwork = false
 	} else if !fFieldsFromHdr && (fFields == nil || len(fFields) == 0) {
 		fFieldsFromHdr = true
 	}


### PR DESCRIPTION
Noticed this issue when writing MMDB files with `--no-fields` specified: we ended up not being able to actually read any data at all as it always told us the entry didn't exist, even though it did exist in the file. This is likely something to do with how the underlying Golang MMDB reader logic works, but in any case we will solve it here by always adding the `network` field when there is no other field to write for an entry.