### PR TITLE
MMDB with nested structures break read and export FIX

### DIFF
--- a/cmd_export.go
+++ b/cmd_export.go
@@ -181,25 +181,8 @@ func cmdExport() error {
 				return fmt.Errorf("failed to get record for next subnet: %w", err)
 			}
 			record["range"] = subnet.String()
-
-			// Unmarshal []interface{} and map[string]interface{} stored as string
-			recordStr := mapInterfaceToStr(record)
-			for key, value := range recordStr {
-				if strings.Contains(value, "[") && value[0] == '[' { //Check if the value is []interface{}
-					var arr1 []interface{}
-					_ = json.Unmarshal([]byte(value), &arr1)
-					if len(arr1) > 0 {
-						record[key] = arr1
-					}
-				} else if strings.Contains(value, "{") && value[0] == '{' { //Check if the value is map[string]interface{}
-					mapConv := make(map[string]interface{})
-					_ = json.Unmarshal([]byte(value), &mapConv)
-					if len(mapConv) > 0 {
-						record[key] = mapConv
-					}
-				}
-			}
-			enc.Encode(record)
+			fmtRecord := unmarshStringJson(record)
+			enc.Encode(fmtRecord)
 		}
 		if err := networks.Err(); err != nil {
 			return fmt.Errorf("failed networks traversal: %w", err)

--- a/cmd_export.go
+++ b/cmd_export.go
@@ -132,7 +132,7 @@ func cmdExport() error {
 			tsvwr := NewTsvWriter(outFile)
 			wr = tsvwr
 		}
-		record := make(map[string]string)
+		record := make(map[string]interface{})
 		networks := db.Networks(maxminddb.SkipAliasedNetworks)
 		for networks.Next() {
 			subnet, err := networks.Network(&record)
@@ -140,11 +140,12 @@ func cmdExport() error {
 				return fmt.Errorf("failed to get record for next subnet: %w", err)
 			}
 
+			recordStr := mapInterfaceToStr(record)
 			if !hdrWritten {
 				hdrWritten = true
 
 				if !fNoHdr {
-					hdr := append([]string{"range"}, sortedMapKeys(record)...)
+					hdr := append([]string{"range"}, sortedMapKeys(recordStr)...)
 					if err := wr.Write(hdr); err != nil {
 						return fmt.Errorf(
 							"failed to write header %v: %w",
@@ -156,7 +157,7 @@ func cmdExport() error {
 
 			line := append(
 				[]string{subnet.String()},
-				sortedMapValsByKeys(record)...,
+				sortedMapValsByKeys(recordStr)...,
 			)
 			if err := wr.Write(line); err != nil {
 				return fmt.Errorf("failed to write line %v: %w", line, err)
@@ -173,7 +174,7 @@ func cmdExport() error {
 		networks := db.Networks(maxminddb.SkipAliasedNetworks)
 		enc := json.NewEncoder(outFile)
 		for networks.Next() {
-			record := make(map[string]string)
+			record := make(map[string]interface{})
 
 			subnet, err := networks.Network(&record)
 			if err != nil {

--- a/cmd_export.go
+++ b/cmd_export.go
@@ -181,6 +181,24 @@ func cmdExport() error {
 				return fmt.Errorf("failed to get record for next subnet: %w", err)
 			}
 			record["range"] = subnet.String()
+
+			// Unmarshal []interface{} and map[string]interface{} stored as string
+			recordStr := mapInterfaceToStr(record)
+			for key, value := range recordStr {
+				if strings.Contains(value, "[") && value[0] == '[' { //Check if the value is []interface{}
+					var arr1 []interface{}
+					_ = json.Unmarshal([]byte(value), &arr1)
+					if len(arr1) > 0 {
+						record[key] = arr1
+					}
+				} else if strings.Contains(value, "{") && value[0] == '{' { //Check if the value is map[string]interface{}
+					mapConv := make(map[string]interface{})
+					_ = json.Unmarshal([]byte(value), &mapConv)
+					if len(mapConv) > 0 {
+						record[key] = mapConv
+					}
+				}
+			}
 			enc.Encode(record)
 		}
 		if err := networks.Err(); err != nil {

--- a/cmd_export.go
+++ b/cmd_export.go
@@ -181,8 +181,7 @@ func cmdExport() error {
 				return fmt.Errorf("failed to get record for next subnet: %w", err)
 			}
 			record["range"] = subnet.String()
-			fmtRecord := unmarshStringJson(record)
-			enc.Encode(fmtRecord)
+			enc.Encode(record)
 		}
 		if err := networks.Err(); err != nil {
 			return fmt.Errorf("failed networks traversal: %w", err)

--- a/cmd_import.go
+++ b/cmd_import.go
@@ -516,8 +516,10 @@ func cmdImport() error {
 			if !fNoNetwork {
 				record["network"] = mmdbtype.String(networkStr)
 			}
-			for k, v := range mResult {
-				record[mmdbtype.String(k)] = mmdbtype.String(v.(string))
+
+			mResultStr := mapInterfaceToStr(mResult)
+			for k, v := range mResultStr {
+				record[mmdbtype.String(k)] = mmdbtype.String(v)
 			}
 
 			// range insertion or cidr insertion?

--- a/cmd_read.go
+++ b/cmd_read.go
@@ -112,7 +112,7 @@ func cmdRead() error {
 		wr = tsvwr
 	}
 	for _, ip := range ips {
-		record := make(map[string]string)
+		record := make(map[string]interface{})
 		if err := db.Lookup(ip, &record); err != nil || len(record) == 0 {
 			if !requiresHdr {
 				fmt.Fprintf(os.Stderr,
@@ -122,12 +122,13 @@ func cmdRead() error {
 			}
 			continue
 		}
+		recordStr := mapInterfaceToStr(record)
 
 		if !hdrWritten {
 			hdrWritten = true
 
 			if requiresHdr {
-				hdr := append([]string{"ip"}, sortedMapKeys(record)...)
+				hdr := append([]string{"ip"}, sortedMapKeys(recordStr)...)
 				if err := wr.Write(hdr); err != nil {
 					return fmt.Errorf(
 						"failed to write header %v: %w",
@@ -158,7 +159,7 @@ func cmdRead() error {
 			}
 			fmt.Printf("%s\n", b)
 		} else { // if fFormat == "csv" || fFormat == "tsv"
-			line := append([]string{ip.String()}, sortedMapValsByKeys(record)...)
+			line := append([]string{ip.String()}, sortedMapValsByKeys(recordStr)...)
 			if err := wr.Write(line); err != nil {
 				return fmt.Errorf("failed to write line %v: %w", line, err)
 			}

--- a/utils.go
+++ b/utils.go
@@ -54,13 +54,13 @@ func mapInterfaceToStr(m map[string]interface{}) map[string]string {
 		case string:
 			retVal[key] = v
 		case map[string]interface{}:
-			outJson, err := json.Marshal(value)
+			outJson, err := json.Marshal(v)
 			if err != nil {
 				return nil
 			}
 			retVal[key] = string(outJson)
 		case []interface{}:
-			outJson, err := json.Marshal(value)
+			outJson, err := json.Marshal(v)
 			if err != nil {
 				return nil
 			}
@@ -68,7 +68,6 @@ func mapInterfaceToStr(m map[string]interface{}) map[string]string {
 		default:
 			retVal[key] = fmt.Sprintf("%v", v)
 		}
-
 	}
 	return retVal
 }

--- a/utils.go
+++ b/utils.go
@@ -73,19 +73,19 @@ func mapInterfaceToStr(m map[string]interface{}) map[string]string {
 	return retVal
 }
 
-// Unmarshal []interface{} and map[string]interface{} stored as string
+// Unmarshal []interface{} and map[string]interface{} stored as string.
 func unmarshStringJson(m map[string]interface{}) map[string]interface{} {
 	retVal := make(map[string]interface{})
 	for key, value := range m {
 		switch v := value.(type) {
 		case string:
-			if strings.Contains(v, "[") && v[0] == '[' { //Check if the value is []interface{}
+			if strings.Contains(v, "[") && v[0] == '[' { // Check if the value is []interface{}.
 				var interfaceArr []interface{}
 				_ = json.Unmarshal([]byte(v), &interfaceArr)
 				if len(interfaceArr) > 0 {
 					retVal[key] = interfaceArr
 				}
-			} else if strings.Contains(v, "{") && v[0] == '{' { //Check if the value is map[string]interface{}
+			} else if strings.Contains(v, "{") && v[0] == '{' { // Check if the value is map[string]interface{}.
 				mapConv := make(map[string]interface{})
 				_ = json.Unmarshal([]byte(v), &mapConv)
 				if len(mapConv) > 0 {

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 )
 
 func sortedMapKeys(m map[string]string) []string {
@@ -54,48 +53,12 @@ func mapInterfaceToStr(m map[string]interface{}) map[string]string {
 			retVal[key] = fmt.Sprintf("%f", v)
 		case string:
 			retVal[key] = v
-		case map[string]interface{}:
+		default:
 			outJson, err := json.Marshal(v)
 			if err != nil {
 				return nil
 			}
 			retVal[key] = string(outJson)
-		case []interface{}:
-			outJson, err := json.Marshal(v)
-			if err != nil {
-				return nil
-			}
-			retVal[key] = string(outJson)
-		default:
-			retVal[key] = fmt.Sprintf("%v", v)
-		}
-	}
-	return retVal
-}
-
-// Unmarshal []interface{} and map[string]interface{} stored as string.
-func unmarshStringJson(m map[string]interface{}) map[string]interface{} {
-	retVal := make(map[string]interface{})
-	for key, value := range m {
-		switch v := value.(type) {
-		case string:
-			if strings.Contains(v, "[") && v[0] == '[' { // Check if the value is []interface{}.
-				var interfaceArr []interface{}
-				_ = json.Unmarshal([]byte(v), &interfaceArr)
-				if len(interfaceArr) > 0 {
-					retVal[key] = interfaceArr
-				}
-			} else if strings.Contains(v, "{") && v[0] == '{' { // Check if the value is map[string]interface{}.
-				mapConv := make(map[string]interface{})
-				_ = json.Unmarshal([]byte(v), &mapConv)
-				if len(mapConv) > 0 {
-					retVal[key] = mapConv
-				}
-			} else {
-				retVal[key] = v
-			}
-		default:
-			retVal[key] = v
 		}
 	}
 	return retVal

--- a/utils.go
+++ b/utils.go
@@ -60,7 +60,11 @@ func mapInterfaceToStr(m map[string]interface{}) map[string]string {
 			}
 			retVal[key] = string(outJson)
 		case []interface{}:
-			retVal[key] = fmt.Sprintf("%v", v)
+			outJson, err := json.Marshal(value)
+			if err != nil {
+				return nil
+			}
+			retVal[key] = string(outJson)
 		default:
 			retVal[key] = fmt.Sprintf("%v", v)
 		}

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"sort"
+	"strconv"
 )
 
 func sortedMapKeys(m map[string]string) []string {
@@ -38,4 +41,30 @@ func longestStrInStringSlice(s []string) string {
 		}
 	}
 	return *longest
+}
+
+func mapInterfaceToStr(m map[string]interface{}) map[string]string {
+	retVal := make(map[string]string)
+	for key, value := range m {
+		switch v := value.(type) {
+		case int:
+			retVal[key] = strconv.Itoa(v)
+		case float64:
+			retVal[key] = fmt.Sprintf("%f", v)
+		case string:
+			retVal[key] = v
+		case map[string]interface{}:
+			outJson, err := json.Marshal(value)
+			if err != nil {
+				return nil
+			}
+			retVal[key] = string(outJson)
+		case []interface{}:
+			retVal[key] = fmt.Sprintf("%v", v)
+		default:
+			retVal[key] = fmt.Sprintf("%v", v)
+		}
+
+	}
+	return retVal
 }

--- a/utils.go
+++ b/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 func sortedMapKeys(m map[string]string) []string {
@@ -67,6 +68,34 @@ func mapInterfaceToStr(m map[string]interface{}) map[string]string {
 			retVal[key] = string(outJson)
 		default:
 			retVal[key] = fmt.Sprintf("%v", v)
+		}
+	}
+	return retVal
+}
+
+// Unmarshal []interface{} and map[string]interface{} stored as string
+func unmarshStringJson(m map[string]interface{}) map[string]interface{} {
+	retVal := make(map[string]interface{})
+	for key, value := range m {
+		switch v := value.(type) {
+		case string:
+			if strings.Contains(v, "[") && v[0] == '[' { //Check if the value is []interface{}
+				var interfaceArr []interface{}
+				_ = json.Unmarshal([]byte(v), &interfaceArr)
+				if len(interfaceArr) > 0 {
+					retVal[key] = interfaceArr
+				}
+			} else if strings.Contains(v, "{") && v[0] == '{' { //Check if the value is map[string]interface{}
+				mapConv := make(map[string]interface{})
+				_ = json.Unmarshal([]byte(v), &mapConv)
+				if len(mapConv) > 0 {
+					retVal[key] = mapConv
+				}
+			} else {
+				retVal[key] = v
+			}
+		default:
+			retVal[key] = v
 		}
 	}
 	return retVal


### PR DESCRIPTION
In this PR, I have fixed the error on nested structure export and read. Please see the following to see how actual `export` and `read` work. 

**Read with ipinfo db:**
![image](https://github.com/ipinfo/mmdbctl/assets/109338796/3fd7a5ca-c848-46a9-9335-facb90d4d23c)

**Read with MaxMind's db:**
![image](https://github.com/ipinfo/mmdbctl/assets/109338796/f004db60-2dc6-452f-96b8-c2387cb6c3b5)
![image](https://github.com/ipinfo/mmdbctl/assets/109338796/fb9aed6d-2baf-44b7-8324-12cf6fa558c1)

**Export with ipinfo db:**
Used [asn.json](https://storage.googleapis.com/ipinfoio/artifacts/v1/asn.json.gz) for this.

JSON:
![image](https://github.com/ipinfo/mmdbctl/assets/109338796/c15cb0b5-7c44-4f0b-ab42-d796dba10c1b)

CSV:
![image](https://github.com/ipinfo/mmdbctl/assets/109338796/804c220b-8d88-42b0-8619-e160d9b2a8d8)

TSV:
![image](https://github.com/ipinfo/mmdbctl/assets/109338796/f5433777-3953-4313-b7bf-b7af4c6ed493)

**Export with MaxMind's db:**

JSON:
`{"continent":{"code":"AF","geoname_id":6255146,"names":{"de":"Afrika","en":"Africa","es":"África","fr":"Afrique","ja":"アフリカ","pt-BR":"África","ru":"Африка","zh-CN":"非洲"}},"country":{"geoname_id":433561,"iso_code":"BI","names":{"de":"Burundi","en":"Burundi","es":"Burundi","fr":"Burundi","ja":"ブルンジ共和国","pt-BR":"Burundi","ru":"Бурунди","zh-CN":"布隆迪"}},"range":"2.18.11.0/24","registered_country":{"geoname_id":2750405,"is_in_european_union":true,"iso_code":"NL","names":{"de":"Niederlande","en":"Netherlands","es":"Holanda","fr":"Pays-Bas","ja":"オランダ王国","pt-BR":"Holanda","ru":"Нидерланды","zh-CN":"荷兰"}}}`
CSV:
![image](https://github.com/ipinfo/mmdbctl/assets/109338796/0b77984e-a953-4c83-aa69-4f9d1ed5f0f6)

TSV:
![image](https://github.com/ipinfo/mmdbctl/assets/109338796/54d1ba89-d6c2-4b16-8fee-78df93534fa6)

I'll spend some more time testing it.