### PR TITLE
import: buffer input file

### DIFF
--- a/cmd_import.go
+++ b/cmd_import.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -323,17 +324,19 @@ func cmdImport() error {
 		defer inFile.Close()
 	}
 
+	inFileBuffered := bufio.NewReaderSize(inFile, 65536)
+
 	entrycnt := 0
 	if delim == ',' || delim == '\t' {
 		var rdr reader
 		if delim == ',' {
-			csvrdr := csv.NewReader(inFile)
+			csvrdr := csv.NewReader(inFileBuffered)
 			csvrdr.Comma = delim
 			csvrdr.LazyQuotes = true
 
 			rdr = csvrdr
 		} else {
-			tsvrdr := NewTsvReader(inFile)
+			tsvrdr := NewTsvReader(inFileBuffered)
 
 			rdr = tsvrdr
 		}
@@ -454,7 +457,7 @@ func cmdImport() error {
 			entrycnt += 1
 		}
 	} else if delim == '-' {
-		dataStream := json.NewDecoder(inFile)
+		dataStream := json.NewDecoder(inFileBuffered)
 		for {
 			// Decode one JSON document.
 			var row interface{}


### PR DESCRIPTION
I noticed that a significant amount of time is spent in `read` syscalls inside the CSV reader.

This buffers read from the input file to reduce the number of syscalls.
I've set the size of the buffer empirically, starting from 4kB until I've stopped seeing improvements.

```bash
cat data.csv | head -n 1000000 | ./mmdbctl import --csv --ip 6 --alias-6to4 --no-network --disallow-reserved > /dev/null
# Before: 25% of time spent in csv.Read
# After: 10% of time spent in csv.Read
```

CPU profiles: [original](https://github.com/ipinfo/mmdbctl/assets/976138/57be18d5-975e-4fb4-a860-ad811f6999b6) [buffered](https://github.com/ipinfo/mmdbctl/assets/976138/356a44e9-8cb1-45ab-866e-cc0689c013ea)

