### PR TITLE
Factor out the import code for reuse in library contexts

### DIFF
--- a/lib/cmd_import.go
+++ b/lib/cmd_import.go
@@ -309,42 +309,12 @@ func CmdImport(f CmdImportFlags, args []string, printHelp func()) error {
 			if !hdrSeen {
 				hdrSeen = true
 
-				// check if the header has a multi-column range.
-				if len(parts) > 1 && parts[0] == "start_ip" && parts[1] == "end_ip" {
-					f.RangeMultiCol = true
+				ParseCSVHeaders(parts, &f, &dataColStart)
 
-					// maybe we also have a join key?
-					if len(parts) > 2 && parts[2] == "join_key" {
-						f.JoinKeyCol = true
-					}
-				}
-
-				if f.RangeMultiCol {
-					if f.JoinKeyCol {
-						dataColStart = 3
-					} else {
-						dataColStart = 2
-					}
-				}
-
-				// need to get fields from hdr?
-				if f.FieldsFromHdr {
-					// skip all non-data columns.
-					f.Fields = parts[dataColStart:]
-				}
-
-				// insert empty values for all fields in 0.0.0.0/0 if requested.
-				if f.IgnoreEmptyVals {
-					_, network, _ := net.ParseCIDR("0.0.0.0/0")
-					record := mmdbtype.Map{}
-					for _, field := range f.Fields {
-						record[mmdbtype.String(field)] = mmdbtype.String("")
-					}
-					if err := tree.Insert(network, record); err != nil {
-						return errors.New(
-							"couldn't insert empty values to 0.0.0.0/0",
-						)
-					}
+				// Now that f.Fields may have been resolved, the preprocessing step can be run
+				err = Preprocess(f, tree)
+				if err != nil {
+					return err
 				}
 
 				// should we skip this first line now?
@@ -362,6 +332,13 @@ func CmdImport(f CmdImportFlags, args []string, printHelp func()) error {
 		}
 	} else if delim == '-' {
 		dataStream := json.NewDecoder(inFileBuffered)
+
+		// For JSON input, f.Fields may have been specified using the --fields flag, so preprocessing can be run
+		err = Preprocess(f, tree)
+		if err != nil {
+			return err
+		}
+
 		for {
 			// Decode one JSON document.
 			var row interface{}
@@ -375,20 +352,6 @@ func CmdImport(f CmdImportFlags, args []string, printHelp func()) error {
 				break
 			}
 			mResult := row.(map[string]interface{})
-
-			// insert empty values for all fields in 0.0.0.0/0 if requested.
-			if f.IgnoreEmptyVals {
-				_, network, _ := net.ParseCIDR("0.0.0.0/0")
-				record := mmdbtype.Map{}
-				for _, field := range f.Fields {
-					record[mmdbtype.String(field)] = mmdbtype.String("")
-				}
-				if err := tree.Insert(network, record); err != nil {
-					return errors.New(
-						"couldn't insert empty values to 0.0.0.0/0",
-					)
-				}
-			}
 
 			// convert 2 IPs into IP range?
 			var networkStr string
@@ -471,6 +434,50 @@ func CmdImport(f CmdImportFlags, args []string, printHelp func()) error {
 	}
 
 	return nil
+}
+
+func Preprocess(f CmdImportFlags, tree *mmdbwriter.Tree) error {
+	// insert empty values for all fields in 0.0.0.0/0 if requested.
+	if f.IgnoreEmptyVals {
+		_, network, _ := net.ParseCIDR("0.0.0.0/0")
+		record := mmdbtype.Map{}
+		for _, field := range f.Fields {
+			record[mmdbtype.String(field)] = mmdbtype.String("")
+		}
+		if err := tree.Insert(network, record); err != nil {
+			return errors.New(
+				"couldn't insert empty values to 0.0.0.0/0",
+			)
+		}
+	}
+
+	return nil
+}
+
+func ParseCSVHeaders(parts []string, f *CmdImportFlags, dataColStart *int) {
+	// check if the header has a multi-column range.
+	if len(parts) > 1 && parts[0] == "start_ip" && parts[1] == "end_ip" {
+		f.RangeMultiCol = true
+
+		// maybe we also have a join key?
+		if len(parts) > 2 && parts[2] == "join_key" {
+			f.JoinKeyCol = true
+		}
+	}
+
+	if f.RangeMultiCol {
+		if f.JoinKeyCol {
+			*dataColStart = 3
+		} else {
+			*dataColStart = 2
+		}
+	}
+
+	// need to get fields from hdr?
+	if f.FieldsFromHdr {
+		// skip all non-data columns.
+		f.Fields = parts[*dataColStart:]
+	}
 }
 
 func AppendCSVRecord(f CmdImportFlags, dataColStart int, delim rune, parts []string, tree *mmdbwriter.Tree) error {


### PR DESCRIPTION
This will enable `mmdbctl` library clients to use the same internal logic as `mmdbctl`, when building MMDB files themselves.

Changes:
- added `AppendCSVRecord` to factor the processing of CSV/TSV entries (there are opportunities to also refactor the JSON code, but it will be done later when needed)
- added `ParseCSVHeaders` to infer import settings from the input CSV/TSV header
- added `Preprocess` to fix different behaviors between CSV/TSV and JSON with regards to `--ignore-empty-values` 