### PR TITLE
added low-level mmdb data to the metadata output

### DIFF
--- a/lib/cmd_metadata.go
+++ b/lib/cmd_metadata.go
@@ -12,6 +12,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
+var (
+	metadataStartMarker = "\xAB\xCD\xEFMaxMind.com"
+)
+
 // CmdMetadataFlags are flags expected by CmdMetadata.
 type CmdMetadataFlags struct {
 	Help    bool
@@ -75,6 +79,27 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 
 	mdFromLib := db.Metadata
 	binaryFmt := strconv.Itoa(int(mdFromLib.BinaryFormatMajorVersion)) + "." + strconv.Itoa(int(mdFromLib.BinaryFormatMinorVersion))
+	treeSize := ((int(mdFromLib.RecordSize) * 2) / 8) * int(mdFromLib.NodeCount)
+	dataSectionStartOffset := treeSize + 16
+	var (
+		dataSectionEndOffset       int
+		dataSectionSize            int
+		metadataSectionStartOffset int
+	)
+
+	// Offset of this separator is used to determine the metadata start section, data section end and data section size.
+	offset, err := findSectionSeparator(args[0], metadataStartMarker)
+	if err != nil {
+		return fmt.Errorf("couldn't process the mmdb file: %w", err)
+	}
+
+	if offset != -1 {
+		dataSectionEndOffset = int(offset)
+		dataSectionSize = int(offset) - treeSize - 16
+		metadataSectionStartOffset = int(offset) + len(metadataStartMarker)
+	} else {
+		return errors.New("input valid mmdb file required as first argument")
+	}
 	if f.Format == "pretty" {
 		fmtEntry := color.New(color.FgCyan)
 		fmtVal := color.New(color.FgGreen)
@@ -93,6 +118,11 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 		printline("IP Version", strconv.Itoa(int(mdFromLib.IPVersion)))
 		printline("Record Size", strconv.Itoa(int(mdFromLib.RecordSize)))
 		printline("Node Count", strconv.Itoa(int(mdFromLib.NodeCount)))
+		printline("Tree Size", strconv.Itoa(treeSize))
+		printline("Data Section Start Offset", strconv.Itoa(dataSectionStartOffset))
+		printline("Data Section End Offset", strconv.Itoa(dataSectionEndOffset))
+		printline("Data Section Size", strconv.Itoa(dataSectionSize))
+		printline("Metadata Section Start Offset", strconv.Itoa(metadataSectionStartOffset))
 		printline("Description", "")
 		descKeys, descVals := sortedMapKeysAndVals(mdFromLib.Description)
 		longestDescKeyLen := strconv.Itoa(len(longestStrInStringSlice(descKeys)))
@@ -107,20 +137,30 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 		printline("Build Epoch", strconv.Itoa(int(mdFromLib.BuildEpoch)))
 	} else { // json
 		md := struct {
-			BinaryFormatVsn string            `json:"binary_format"`
-			DatabaseType    string            `json:"db_type"`
-			IPVersion       uint              `json:"ip"`
-			RecordSize      uint              `json:"record_size"`
-			NodeCount       uint              `json:"node_count"`
-			Description     map[string]string `json:"description"`
-			Languages       []string          `json:"languages"`
-			BuildEpoch      uint              `json:"build_epoch"`
+			BinaryFormatVsn        string            `json:"binary_format"`
+			DatabaseType           string            `json:"db_type"`
+			IPVersion              uint              `json:"ip"`
+			RecordSize             uint              `json:"record_size"`
+			NodeCount              uint              `json:"node_count"`
+			TreeSize               uint              `json:"tree_size"`
+			DataSectionStartOffset uint              `json:"data_section_start_offset"`
+			DataSectionEndOffset   uint              `json:"data_section_end_offset"`
+			DataSectionSize        uint              `json:"data_section_size"`
+			MetadataStartOffset    uint              `json:"metadata_section_start_offset"`
+			Description            map[string]string `json:"description"`
+			Languages              []string          `json:"languages"`
+			BuildEpoch             uint              `json:"build_epoch"`
 		}{
 			binaryFmt,
 			mdFromLib.DatabaseType,
 			mdFromLib.IPVersion,
 			mdFromLib.RecordSize,
 			mdFromLib.NodeCount,
+			uint(treeSize),
+			uint(dataSectionStartOffset),
+			uint(dataSectionEndOffset),
+			uint(dataSectionSize),
+			uint(metadataSectionStartOffset),
 			mdFromLib.Description,
 			mdFromLib.Languages,
 			mdFromLib.BuildEpoch,


### PR DESCRIPTION
`mmdbctl metadata` output now shows the low-level data of an mmdb file listed in #25.

P.S:
Have incorporated the basic math formulas in our code for now in case this [PR](https://github.com/maxmind/mmdbwriter/pull/76) isn't reviewed or rejected.