### PR TITLE
added type sizes info found within the data section

### DIFF
--- a/cmd_metadata.go
+++ b/cmd_metadata.go
@@ -13,11 +13,12 @@ var predictMetadataFmts = []string{"pretty", "json"}
 
 var completionsMetadata = &complete.Command{
 	Flags: map[string]complete.Predictor{
-		"--nocolor": predict.Nothing,
-		"-h":        predict.Nothing,
-		"--help":    predict.Nothing,
-		"-f":        predict.Set(predictMetadataFmts),
-		"--format":  predict.Set(predictMetadataFmts),
+		"--nocolor":    predict.Nothing,
+		"--data-types": predict.Nothing,
+		"-h":           predict.Nothing,
+		"--help":       predict.Nothing,
+		"-f":           predict.Set(predictMetadataFmts),
+		"--format":     predict.Set(predictMetadataFmts),
 	},
 }
 
@@ -29,6 +30,8 @@ Options:
   General:
     --nocolor
       disable colored output.
+    --data-types
+      show data type sizes within the data section.
     --help, -h
       show help.
 

--- a/lib/cmd_metadata.go
+++ b/lib/cmd_metadata.go
@@ -76,8 +76,8 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 		return errors.New("format must be one of \"pretty\" or \"json\"")
 	}
 
-	mmdbFile := args[0]
 	// open tree.
+	mmdbFile := args[0]
 	db, err := maxminddb.Open(mmdbFile)
 	if err != nil {
 		return fmt.Errorf("couldn't open mmdb file: %w", err)

--- a/lib/cmd_metadata.go
+++ b/lib/cmd_metadata.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -77,14 +76,9 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 		return errors.New("format must be one of \"pretty\" or \"json\"")
 	}
 
-	mmdbFile, err := os.Open(args[0])
-	if err != nil {
-		return fmt.Errorf("couldn't open mmdb file: %w", err)
-	}
-	defer mmdbFile.Close()
-
+	mmdbFile := args[0]
 	// open tree.
-	db, err := maxminddb.Open(args[0])
+	db, err := maxminddb.Open(mmdbFile)
 	if err != nil {
 		return fmt.Errorf("couldn't open mmdb file: %w", err)
 	}
@@ -116,7 +110,6 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 			return fmt.Errorf("couldn't process the mmdb file: %w", err)
 		}
 	}
-
 	metadataSectionStartOffset = int(offset) + len(MetadataStartMarker)
 
 	if f.Format == "pretty" {
@@ -135,7 +128,6 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 		}
 
 		printline := printlineGen("", "13")
-
 		printline("Binary Format", binaryFmt, "")
 		printline("Database Type", mdFromLib.DatabaseType, "")
 		printline("IP Version", strconv.Itoa(int(mdFromLib.IPVersion)), "")
@@ -186,7 +178,7 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 			NodeCount              uint              `json:"node_count"`
 			TreeSize               uint              `json:"tree_size"`
 			DataSectionSize        uint              `json:"data_section_size"`
-			TypeSize               *TypeSizes        `json:"type_size,omitempty"`
+			TypeSize               *TypeSizes        `json:"data_type_sizes,omitempty"`
 			DataSectionStartOffset uint              `json:"data_section_start_offset"`
 			DataSectionEndOffset   uint              `json:"data_section_end_offset"`
 			MetadataStartOffset    uint              `json:"metadata_section_start_offset"`

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -96,3 +96,181 @@ func findSectionSeparator(mmdbFile, sep string) (int64, error) {
 
 	return -1, nil
 }
+
+type TypeSizes struct {
+	PointerSize           int64
+	Utf8StringSize        int64
+	DoubleSize            int64
+	BytesSize             int64
+	Unsigned16bitIntSize  int64
+	Unsigned32bitIntSize  int64
+	Signed32bitIntSize    int64
+	Unsigned64bitIntSize  int64
+	Unsigned128bitIntSize int64
+	MapKeyValueCount      int64
+	ArrayLength           int64
+	FloatSize             int64
+}
+
+func traverseDataSection(filePath string, startOffset, endOffset int64) (TypeSizes, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return TypeSizes{}, err
+	}
+	defer file.Close()
+
+	// Go to the start offset of the data section.
+	_, err = file.Seek(startOffset, 0)
+	if err != nil {
+		return TypeSizes{}, err
+	}
+
+	var typeSizes TypeSizes
+
+	// Read and process bytes until the end offset is reached.
+	for offset := startOffset; offset < endOffset; {
+		var controlByte [1]byte
+		_, err := file.Read(controlByte[:])
+		if err != nil {
+			return TypeSizes{}, err
+		}
+		offset++
+
+		// Extract the type from the control byte.
+		dataType := controlByte[0] & 0b111 // First three bits represent the type.
+		// Check if it's an extended type.
+		if dataType == 0 {
+			// Read actual type number from the next byte
+			var extendedTypeByte [1]byte
+			_, err := file.Read(extendedTypeByte[:])
+			if err != nil {
+				return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+			}
+			offset++
+			payloadSize := int(controlByte[0] & 0b00011111) // Last five bits represent payload size
+			switch extendedTypeByte[0] {
+			case 1: // unsigned 32-bit int.
+
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.Signed32bitIntSize += int64(payloadSize)
+
+			case 2: // unsigned 64-bit int.
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.Unsigned64bitIntSize += int64(payloadSize)
+
+			case 3: // unsigned 128-bit int.
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.Unsigned128bitIntSize += int64(payloadSize)
+
+			case 4: // array.
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.ArrayLength += int64(payloadSize)
+
+			case 8: // float.
+				typeSizes.FloatSize += 4
+			}
+		} else {
+			payloadSize := int(controlByte[0] & 0b00011111) // Last five bits represent payload size.
+			// Process based on the data type.
+			switch dataType {
+			case 1: // Pointer.
+				size := int((controlByte[0] >> 3) & 0b00000011) // Extract the size bits at position 3 and 4.
+				switch size {
+				case 1:
+					typeSizes.PointerSize += 1
+				case 2:
+					typeSizes.PointerSize += 2
+				case 3:
+					typeSizes.PointerSize += 3
+				}
+
+			case 2: // UTF-8 string.
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.Utf8StringSize += int64(payloadSize)
+
+			case 3: // Double.
+				typeSizes.DoubleSize += 8
+
+			case 4: // Byte.
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.BytesSize += int64(payloadSize)
+
+			case 5: // unsigned 16-bit int.
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.Unsigned16bitIntSize += int64(payloadSize)
+
+			case 6: // unsigned 32-bit int.
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.Unsigned32bitIntSize += int64(payloadSize)
+
+			case 7: // map.
+				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				if err != nil {
+					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
+				}
+				typeSizes.MapKeyValueCount += int64(payloadSize)
+			}
+		}
+
+	}
+
+	return typeSizes, nil
+}
+
+// This is used for further calculation on the current payload size if it is either 29, 30 or 31.
+func payloadCalculation(file *os.File, payloadSize int, offset int64) (int, int64, error) {
+	if payloadSize == 29 {
+		// Read the next byte as the payload size.
+		var nextByte [1]byte
+		_, err := file.Read(nextByte[:])
+		if err != nil {
+			return -1, -1, err
+		}
+		payloadSize = int(nextByte[0]) + 29
+		offset++
+	} else if payloadSize == 30 {
+		// Read the next two bytes as the payload size.
+		var nextBytes [2]byte
+		_, err := file.Read(nextBytes[:])
+		if err != nil {
+			return -1, -1, err
+		}
+		payloadSize = int(nextBytes[0])<<8 + int(nextBytes[1]) + 285
+		offset += 2
+	} else if payloadSize == 31 {
+		// Read the next three bytes as the payload size.
+		var nextBytes [3]byte
+		_, err := file.Read(nextBytes[:])
+		if err != nil {
+			return -1, -1, err
+		}
+		payloadSize = int(nextBytes[0])<<16 + int(nextBytes[1])<<8 + int(nextBytes[2]) + 65821
+		offset += 3
+	}
+
+	return payloadSize, offset, nil
+}

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strconv"
@@ -67,14 +68,8 @@ func mapInterfaceToStr(m map[string]interface{}) map[string]string {
 	return retVal
 }
 
-func findSectionSeparator(mmdbFile, sep string) (int64, error) {
-	file, err := os.Open(mmdbFile)
-	if err != nil {
-		return 0, err
-	}
-	defer file.Close()
-
-	fileInfo, err := file.Stat()
+func findSectionSeparator(mmdbFile *os.File, sep string) (int64, error) {
+	fileInfo, err := mmdbFile.Stat()
 	if err != nil {
 		return 0, err
 	}
@@ -82,7 +77,7 @@ func findSectionSeparator(mmdbFile, sep string) (int64, error) {
 	fileSize := fileInfo.Size()
 
 	// Map the mmdb file into memory.
-	mmap, err := syscall.Mmap(int(file.Fd()), 0, int(fileSize), syscall.PROT_READ, syscall.MAP_SHARED)
+	mmap, err := syscall.Mmap(int(mmdbFile.Fd()), 0, int(fileSize), syscall.PROT_READ, syscall.MAP_SHARED)
 	if err != nil {
 		return 0, err
 	}
@@ -97,30 +92,47 @@ func findSectionSeparator(mmdbFile, sep string) (int64, error) {
 	return -1, nil
 }
 
-type TypeSizes struct {
-	PointerSize           int64
-	Utf8StringSize        int64
-	DoubleSize            int64
-	BytesSize             int64
-	Unsigned16bitIntSize  int64
-	Unsigned32bitIntSize  int64
-	Signed32bitIntSize    int64
-	Unsigned64bitIntSize  int64
-	Unsigned128bitIntSize int64
-	MapKeyValueCount      int64
-	ArrayLength           int64
-	FloatSize             int64
+func simplifySize(size int64) string {
+	const (
+		_  = iota
+		KB = 1 << (10 * iota)
+		MB
+		GB
+		TB
+	)
+
+	if size >= TB {
+		return fmt.Sprintf("(%.2f TB)", float64(size)/float64(TB))
+	} else if size >= GB {
+		return fmt.Sprintf("(%.2f GB)", float64(size)/float64(GB))
+	} else if size >= MB {
+		return fmt.Sprintf("(%.2f MB)", float64(size)/float64(MB))
+	} else if size >= KB {
+		return fmt.Sprintf("(%.2f KB)", float64(size)/float64(KB))
+	} else {
+		return ""
+	}
+
 }
 
-func traverseDataSection(filePath string, startOffset, endOffset int64) (TypeSizes, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return TypeSizes{}, err
-	}
-	defer file.Close()
+type TypeSizes struct {
+	PointerSize           int64 `json:"pointer_size"`
+	Utf8StringSize        int64 `json:"utf8_string_size"`
+	DoubleSize            int64 `json:"double_size"`
+	BytesSize             int64 `json:"bytes_size"`
+	Unsigned16bitIntSize  int64 `json:"unsigned_16-bit_int_size"`
+	Unsigned32bitIntSize  int64 `json:"unsigned_32-bit_int_size"`
+	Signed32bitIntSize    int64 `json:"signed_32-bit_int_size"`
+	Unsigned64bitIntSize  int64 `json:"unsigned_64-bit_int_size"`
+	Unsigned128bitIntSize int64 `json:"unsigned_128-bit_int_size"`
+	MapKeyValueCount      int64 `json:"map_key_value_pair_count"`
+	ArrayLength           int64 `json:"array_length"`
+	FloatSize             int64 `json:"float_size"`
+}
 
+func traverseDataSection(mmdbFile *os.File, startOffset int64, endOffset int64) (TypeSizes, error) {
 	// Go to the start offset of the data section.
-	_, err = file.Seek(startOffset, 0)
+	_, err := mmdbFile.Seek(startOffset, 0)
 	if err != nil {
 		return TypeSizes{}, err
 	}
@@ -130,59 +142,55 @@ func traverseDataSection(filePath string, startOffset, endOffset int64) (TypeSiz
 	// Read and process bytes until the end offset is reached.
 	for offset := startOffset; offset < endOffset; {
 		var controlByte [1]byte
-		_, err := file.Read(controlByte[:])
+		_, err := mmdbFile.Read(controlByte[:])
 		if err != nil {
 			return TypeSizes{}, err
 		}
 		offset++
 
 		// Extract the type from the control byte.
-		dataType := controlByte[0] & 0b111 // First three bits represent the type.
+		dataType := (controlByte[0] >> 5) & 0b00000111 // Most significant 3 bits represent the type.
+		// Extract the payload size from the control byte.
+		payloadSize := int(controlByte[0] & 0b00011111) // Least significant 5 bits represent payload size.
 		// Check if it's an extended type.
 		if dataType == 0 {
 			// Read actual type number from the next byte
 			var extendedTypeByte [1]byte
-			_, err := file.Read(extendedTypeByte[:])
+			_, err := mmdbFile.Read(extendedTypeByte[:])
 			if err != nil {
 				return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 			}
 			offset++
-			payloadSize := int(controlByte[0] & 0b00011111) // Last five bits represent payload size
+
 			switch extendedTypeByte[0] {
 			case 1: // unsigned 32-bit int.
-
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
 				typeSizes.Signed32bitIntSize += int64(payloadSize)
-
 			case 2: // unsigned 64-bit int.
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
 				typeSizes.Unsigned64bitIntSize += int64(payloadSize)
-
 			case 3: // unsigned 128-bit int.
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
 				typeSizes.Unsigned128bitIntSize += int64(payloadSize)
-
 			case 4: // array.
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
 				typeSizes.ArrayLength += int64(payloadSize)
-
 			case 8: // float.
 				typeSizes.FloatSize += 4
 			}
 		} else {
-			payloadSize := int(controlByte[0] & 0b00011111) // Last five bits represent payload size.
 			// Process based on the data type.
 			switch dataType {
 			case 1: // Pointer.
@@ -195,40 +203,34 @@ func traverseDataSection(filePath string, startOffset, endOffset int64) (TypeSiz
 				case 3:
 					typeSizes.PointerSize += 3
 				}
-
 			case 2: // UTF-8 string.
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
 				typeSizes.Utf8StringSize += int64(payloadSize)
-
 			case 3: // Double.
 				typeSizes.DoubleSize += 8
-
 			case 4: // Byte.
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
 				typeSizes.BytesSize += int64(payloadSize)
-
 			case 5: // unsigned 16-bit int.
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
 				typeSizes.Unsigned16bitIntSize += int64(payloadSize)
-
 			case 6: // unsigned 32-bit int.
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
 				typeSizes.Unsigned32bitIntSize += int64(payloadSize)
-
 			case 7: // map.
-				payloadSize, offset, err = payloadCalculation(file, payloadSize, offset)
+				payloadSize, offset, err = payloadCalculation(mmdbFile, payloadSize, offset)
 				if err != nil {
 					return TypeSizes{}, fmt.Errorf("couldn't read the file: %v", err)
 				}
@@ -242,11 +244,11 @@ func traverseDataSection(filePath string, startOffset, endOffset int64) (TypeSiz
 }
 
 // This is used for further calculation on the current payload size if it is either 29, 30 or 31.
-func payloadCalculation(file *os.File, payloadSize int, offset int64) (int, int64, error) {
+func payloadCalculation(mmdbFile io.Reader, payloadSize int, offset int64) (int, int64, error) {
 	if payloadSize == 29 {
 		// Read the next byte as the payload size.
 		var nextByte [1]byte
-		_, err := file.Read(nextByte[:])
+		_, err := mmdbFile.Read(nextByte[:])
 		if err != nil {
 			return -1, -1, err
 		}
@@ -255,7 +257,7 @@ func payloadCalculation(file *os.File, payloadSize int, offset int64) (int, int6
 	} else if payloadSize == 30 {
 		// Read the next two bytes as the payload size.
 		var nextBytes [2]byte
-		_, err := file.Read(nextBytes[:])
+		_, err := mmdbFile.Read(nextBytes[:])
 		if err != nil {
 			return -1, -1, err
 		}
@@ -264,7 +266,7 @@ func payloadCalculation(file *os.File, payloadSize int, offset int64) (int, int6
 	} else if payloadSize == 31 {
 		// Read the next three bytes as the payload size.
 		var nextBytes [3]byte
-		_, err := file.Read(nextBytes[:])
+		_, err := mmdbFile.Read(nextBytes[:])
 		if err != nil {
 			return -1, -1, err
 		}


### PR DESCRIPTION
`mmdbctl metadata` output includes data types within the data section along with their size/length.