### PR TITLE
Improve release tooling

### DIFF
--- a/.github/workflows/cd_github.yaml
+++ b/.github/workflows/cd_github.yaml
@@ -48,6 +48,9 @@ jobs:
     - name: Build
       run: ./scripts/build-archive-all.sh ${{ env.CLI_VERSION }}
 
+    - name: Update platform scripts version
+      run: ./scripts/update-platform-scripts-version.sh ${{ env.CLI_VERSION }}
+
     - name: Generate changelog
       run: ./scripts/changelog.sh ${{ env.CLI_VERSION }} > changes.md
 
@@ -62,3 +65,16 @@ jobs:
           ./macos.sh
           ./windows.ps1
           ./deb.sh
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: |
+            - ./CHANGELOG.md
+            - ./README.md
+            - ./deb.sh
+            - ./dist/DEBIAN/control
+            - ./macos.sh
+            - ./windows.ps1
+          message: "Release `${{ env.CLI_VERSION }}`"
+          push: "origin master"
+          default_author: "github_actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
+# 1.4.4
+
+- Revert back to `maxmind/mmdbwriter`
+
 # 1.4.3
 
-* Temporarily use max-info/mmdbwriter
-
-## Pull Requests
-
-* [#18](https://github.com/ipinfo/mmdbctl/pull/18)
+- Temporarily use `max-info/mmdbwriter`

--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ The `mmdbctl` CLI is available for download via multiple mechanisms.
 Install the latest `amd64` version:
 
 ```bash
-curl -Ls https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.3/macos.sh | sh
+curl -Ls https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.4/macos.sh | sh
 ```
 
 ### Debian / Ubuntu (amd64)
 
 ```bash
-curl -Ls https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.3/deb.sh | sh
+curl -Ls https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.4/deb.sh | sh
 ```
 
 OR
 
 ```bash
-curl -LO https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.3/mmdbctl_1.4.3.deb
-sudo dpkg -i mmdbctl_1.4.3.deb
+curl -LO https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.4/mmdbctl_1.4.4.deb
+sudo dpkg -i mmdbctl_1.4.4.deb
 ```
 
 ### Windows Powershell
@@ -40,7 +40,7 @@ sudo dpkg -i mmdbctl_1.4.3.deb
 _Note_: run powershell as administrator before executing this command.
 
 ```bash
-iwr -useb https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.3/windows.ps1 | iex
+iwr -useb https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.4/windows.ps1 | iex
 ```
 
 ### Using `go install`
@@ -91,11 +91,11 @@ After choosing a platform `PLAT` from above, run:
 
 ```bash
 # for Windows, use ".zip" instead of ".tar.gz"
-curl -LO https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.3/mmdbctl_1.4.3_${PLAT}.tar.gz
+curl -LO https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.4/mmdbctl_1.4.4_${PLAT}.tar.gz
 # OR
-wget https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.3/mmdbctl_1.4.3_${PLAT}.tar.gz
-tar -xvf mmdbctl_1.4.3_${PLAT}.tar.gz
-mv mmdbctl_1.4.3_${PLAT} /usr/local/bin/mmdbctl
+wget https://github.com/ipinfo/mmdbctl/releases/download/mmdbctl-1.4.4/mmdbctl_1.4.4_${PLAT}.tar.gz
+tar -xvf mmdbctl_1.4.4_${PLAT}.tar.gz
+mv mmdbctl_1.4.4_${PLAT} /usr/local/bin/mmdbctl
 ```
 
 ### Using `git`

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Add commits (except merge commits) since current release
+
+set -e
+
+DIR=`dirname $0`
+ROOT=$DIR/..
+
+REPO_URL=https://www.github.com/ipinfo/mmdbctl
+CHANGES=CHANGELOG.added.md
+
+VSN=$1
+
+if [ -z "${VSN}" ]; then
+    echo "require version as parameter" 2>&1
+    exit 1
+fi
+
+
+LATEST_RELEASE_VERSION=$(wget -qO- https://api.github.com/repos/ipinfo/mmdbctl/releases/latest | jq -r ".tag_name")
+LATEST_RELEASE_SEMVER=$(echo ${LATEST_RELEASE_VERSION} | sed 's/mmdbctl-//' )
+
+# Build list of commits since last release
+echo -e "# ${VSN}\n" > $CHANGES
+git log ${LATEST_RELEASE_VERSION}..origin/master --oneline --no-merges | while read -r line; do
+    COMMIT_HASH=$(echo $line | cut -d' ' -f1)
+    COMMIT_MESSAGE=$(echo $line | cut -d' ' -f2-)
+
+    echo "- [${COMMIT_HASH}](${REPO_URL}/commit/${COMMIT_HASH}) ${COMMIT_MESSAGE}" >> $CHANGES
+done
+echo "" >> $CHANGES
+
+# Overwrite CHANGELOG
+cat $CHANGES CHANGELOG.md > CHANGELOG.md.new
+mv CHANGELOG.md.new CHANGELOG.md
+rm $CHANGES
+
+# Update README with new version
+cat README.md | sed "s/${LATEST_RELEASE_SEMVER}/${VSN}/" > README.md.new
+mv README.md.new README.md

--- a/scripts/update-platform-scripts-version.sh
+++ b/scripts/update-platform-scripts-version.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Builds versioned platforms scripts (deb.sh, macos.sh, windows.ps1, dist/DEBIAN/control)
+
+set -e
+
+DIR=`dirname $0`
+ROOT=$DIR/..
+
+VSN=$1
+
+if [ -z "$VSN" ]; then
+    echo "require version as parameter" 2>&1
+    exit 1
+fi
+
+# Generate new versions separately (otherwise we get an empty file)
+cat $ROOT/deb.sh | sed "s/VSN=.*/VSN=${VSN}/" > $ROOT/deb.sh.new
+cat $ROOT/macos.sh | sed "s/VSN=.*/VSN=${VSN}/" > $ROOT/macos.sh.new
+cat $ROOT/windows.ps1 | sed "s/\$VSN =.*/\$VSN = \"${VSN}\"/" > $ROOT/windows.ps1.new
+cat $ROOT/dist/DEBIAN/control | sed "s/Version: .*/Version: ${VSN}/" > $ROOT/dist/DEBIAN/control.new
+
+mv $ROOT/deb.sh.new $ROOT/deb.sh
+mv $ROOT/macos.sh.new $ROOT/macos.sh
+mv $ROOT/windows.ps1.new $ROOT/windows.ps1
+mv $ROOT/dist/DEBIAN/control.new $ROOT/dist/DEBIAN/control
+
+if [ "$(git diff --shortstat)" = " 4 files changed, 4 insertions(+), 4 deletions(-)" ] ; then
+  echo "Success"
+else
+    echo "Platform scripts version update failed" 2>&1
+    git diff | cat 2>&1
+    exit 1
+fi


### PR DESCRIPTION
- platform scripts are updated in the release workflow ([mmdbctl#36 1.4.4 deb.sh script downloads 1.4.3](https://github.com/ipinfo/mmdbctl/issues/36))
-  `./scripts/prepare-release.sh` is used to prepopulate `CHANGELOG` and  to update`README`
- release workflow commits new version as its commit