### PR TITLE
Switch to "github.com/edsrzf/mmap-go" for cross-platform mmap implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/edsrzf/mmap-go v1.1.0 h1:6EUwBLQ/Mcr1EYLE4Tn1VdW1A4ckqCQWZBw8Hr0kjpQ=
+github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -8,7 +8,8 @@ import (
 	"os"
 	"sort"
 	"strconv"
-	"syscall"
+
+	"github.com/edsrzf/mmap-go"
 )
 
 func sortedMapKeys(m map[string]string) []string {
@@ -75,19 +76,12 @@ func findSectionSeparator(mmdbFile string, sep string) (int64, error) {
 	}
 	defer file.Close()
 
-	fileInfo, err := file.Stat()
-	if err != nil {
-		return 0, err
-	}
-
-	fileSize := fileInfo.Size()
-
 	// Map the mmdb file into memory.
-	mmap, err := syscall.Mmap(int(file.Fd()), 0, int(fileSize), syscall.PROT_READ, syscall.MAP_SHARED)
+	mmap, err := mmap.Map(file, mmap.RDONLY, 0)
 	if err != nil {
 		return 0, err
 	}
-	defer syscall.Munmap(mmap)
+	defer mmap.Unmap()
 
 	// Search the last occurrence of the separator in the file.
 	index := bytes.LastIndex(mmap, []byte(sep))


### PR DESCRIPTION


`syscall.Mmap` is not supported on Windows:
```
Error: lib/utils.go:86:23: undefined: syscall.Mmap
Error: lib/utils.go:86:70: undefined: syscall.PROT_READ
Error: lib/utils.go:86:89: undefined: syscall.MAP_SHARED
Error: lib/utils.go:90:16: undefined: syscall.Munmap
```

### Testing

```
$ GOOS=windows GOARCH=386 go build -o mmdbctl-win386 .
$ go build .
```