### PR TITLE
cmd/metadata: do not show size for node count

### DIFF
--- a/lib/cmd_metadata.go
+++ b/lib/cmd_metadata.go
@@ -132,7 +132,7 @@ func CmdMetadata(f CmdMetadataFlags, args []string, printHelp func()) error {
 		printline("Database Type", mdFromLib.DatabaseType, "")
 		printline("IP Version", strconv.Itoa(int(mdFromLib.IPVersion)), "")
 		printline("Record Size", strconv.Itoa(int(mdFromLib.RecordSize)), simplifySize(int64(mdFromLib.RecordSize)))
-		printline("Node Count", strconv.Itoa(int(mdFromLib.NodeCount)), simplifySize(int64(mdFromLib.NodeCount)))
+		printline("Node Count", strconv.Itoa(int(mdFromLib.NodeCount)), "")
 		printline("Tree Size", strconv.Itoa(treeSize), simplifySize(int64(treeSize)))
 		printline("Data Section Size", strconv.Itoa(dataSectionSize), simplifySize(int64(dataSectionSize)))
 		if f.DataTypes {


### PR DESCRIPTION
It's a node count, doesn't make sense to convert in MBs :-)

The actual tree size is shown in the next line.

```bash
mmdbctl metadata proxy_residential.mmdb
...
- Node Count    920825782 (878.17 MB) # <--- Remove this size
- Tree Size     7366606256 (6.86 GB)
- Data Section Size 1774958 (1.69 MB)
...
```